### PR TITLE
[REQUEST] Kernel modules from Reno4 SE for Android 10 (vendor/mediatek/kernel_modules)

### DIFF
--- a/kernel-4.14/README
+++ b/kernel-4.14/README
@@ -16,3 +16,4 @@ See Documentation/00-INDEX for a list of what is contained in each file.
 Please read the Documentation/process/changes.rst file, as it contains the
 requirements for building and running the kernel, and information about
 the problems which may result by upgrading your kernel.
+


### PR DESCRIPTION
Hey @oppo-source could you push **vendor/mediatek/kernel_modules from OPPO Reno4 SE for Android 10** asap please ? Those modules **(bt_drv.ko, fmradio_drv.ko, fpsgo.ko, gps_drv.ko, met.ko, wlan_drv_gen4m.ko, wmt_chrdev_wifi.ko and wmt_drv.ko)** are under **GPLv2 licensing**. Thanks